### PR TITLE
Added urlArgs support(like requirejs urlArgs), added support for absolute urls, updated readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,19 +100,19 @@ The rendered HTML will look like this:
 * `urlArgs` are extra query string arguments appended to relative path URLs
 
 The above configuration is ignored if absolute url is provided. eg:
-```
+```js
 addScript('footer', 'https://cdnjs.cloudflare.com/ajax/libs/require.min.js')
 ```
 OR
-````
+````js
 addScript('footer', '//cdnjs.cloudflare.com/ajax/libs/require.min.js')
 ```
 OR
-```
+```js
 addScript('footer', 'http//cdnjs.cloudflare.com/ajax/libs/equire.min.js')
 ```
-Then the original url is used and in the second case, when `scripts('footer')`
-is used it will result to:
+Then the original url is used and in the second case when `scripts('footer')`
+is called, no matter what configuration is used, it will result to:
 ```html
 <script src="//cdnjs.cloudflare.com/ajax/libs/require.min.js"></script>
 ```

--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ var ejsHelper = require('ejs-helper');
 
 app.use(ejsHelper({
     cssPath: '/static/css/',
-    jsPath: '/static/js/'
+    jsPath: '/static/js/',
+    urlArgs: 'v='+requie("package.json").version+'&awesomeness=true'
 }));
 ```
 
@@ -96,7 +97,25 @@ The rendered HTML will look like this:
 
 * `cssPath` will be prepended to the filename of the CSS href
 * `jsPath` will be prepended to the filename of the script src
+* `urlArgs` are extra query string arguments appended to relative path URLs
 
+The above configuration is ignored if absolute url is provided. eg:
+```
+addScript('footer', 'https://cdnjs.cloudflare.com/ajax/libs/require.min.js')
+```
+OR
+````
+addScript('footer', '//cdnjs.cloudflare.com/ajax/libs/require.min.js')
+```
+OR
+```
+addScript('footer', 'http//cdnjs.cloudflare.com/ajax/libs/equire.min.js')
+```
+Then the original url is used. For example the secnd case, when `scripts('footer')`
+is used it will result to:
+```
+<script src="//cdnjs.cloudflare.com/ajax/libs/require.min.js"></script>
+```
 ## Methods
 
 You can use these methods in your template.

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ OR
 ```js
 addScript('footer', 'http//cdnjs.cloudflare.com/ajax/libs/equire.min.js')
 ```
-Then the original url is used and in the second case when `scripts('footer')`
+Then the original url is used and for example in the second case when `scripts('footer')`
 is called, no matter what configuration is used, it will result to:
 ```html
 <script src="//cdnjs.cloudflare.com/ajax/libs/require.min.js"></script>

--- a/README.md
+++ b/README.md
@@ -111,9 +111,9 @@ OR
 ```
 addScript('footer', 'http//cdnjs.cloudflare.com/ajax/libs/equire.min.js')
 ```
-Then the original url is used. For example the secnd case, when `scripts('footer')`
+Then the original url is used and in the second case, when `scripts('footer')`
 is used it will result to:
-```
+```html
 <script src="//cdnjs.cloudflare.com/ajax/libs/require.min.js"></script>
 ```
 ## Methods

--- a/lib/ejs-helper.js
+++ b/lib/ejs-helper.js
@@ -1,16 +1,51 @@
 module.exports = function(config) {
+  var basePathRegex=new RegExp("^(http:|https:)?//");
+
   if (!config)
     var config = {};
-  if (!config.cssPath)
+    
+  //normalize url form(to end in /)
+  if (!config.cssPath) {
     config.cssPath = "";
-  if (!config.jsPath)
-    config.jsPath = "";
-  if (!config.urlArgs){
-    config.urlArgs = "";
-  }else{
-    config.urlArgs = config.urlArgs.indexOf("?")==0?config.urlArgs:("?"+config.urlArgs);
+  }else if(config.cssPath[config.cssPath.length-1]!=="/") {
+    config.cssPath+="/";
   }
 
+  if (!config.jsPath) {
+    config.jsPath = "";
+  }else if(config.jsPath[config.jsPath.length-1]!=="/") {
+    config.jsPath+="/";
+  }
+  /*urlArgs as in requirejs config.
+   *The search portion of the url,
+   *could be useful for setting asset
+   *version e.t.c
+   */
+  if (!config.urlArgs) {
+    config.urlArgs = "";
+  }else if(config.urlArgs[0] !== "?") {
+    config.urlArgs = ("?"+config.urlArgs);
+  }
+
+  /**
+   * Private function that detects whether the the base is
+   * found in the url and returns it in the right form.
+   * Asuming that an absolute path url is pointing to a
+   * third party server, site wide urlArgs configuration
+   * is ignored and the original url is returned in that case.
+   * @param   {string} path   Any of the configured path keys 
+   *                          "jsPath", "cssPath".
+   * @param   {string} src    The ptovided url path relative
+   *                          or absolute.
+   * @returns {string}        Prepared url with urlArgs or 
+   *                          the original abslute url.
+   */
+  function constructUrl(path,src){
+      if (basePathRegex.test(src)||!config[path]) {
+          return src;
+      }
+      return  config[path] + src + config.urlArgs;
+  }
   return function(req, res, next) {
     var title = "";
     var styles = [];
@@ -40,7 +75,7 @@ module.exports = function(config) {
       var output = '';
 
       scripts[place].forEach(function (script) {
-        output += '<script src=' + config.jsPath + '/' + script.src + config.urlArgs;
+          output += '<script src=' + constructUrl("jsPath", script.src);
         for (attribute in script.attributes) {
           output += ' ' + attribute + '="' + script.attributes[attribute] + '"';
         }
@@ -54,7 +89,7 @@ module.exports = function(config) {
       var output = '';
 
       styles.forEach(function (style) {
-          output += '<link href="' + config.cssPath + style.src + config.urlArgs + '"';
+          output += '<link href="' + constructUrl("cssPath", style.src) + '"';
         for (attribute in style.attributes) {
           output += ' ' + attribute + '="' + style.attributes[attribute] + '"';
         }

--- a/lib/ejs-helper.js
+++ b/lib/ejs-helper.js
@@ -5,6 +5,11 @@ module.exports = function(config) {
     config.cssPath = "";
   if (!config.jsPath)
     config.jsPath = "";
+  if (!config.urlArgs){
+    config.urlArgs = "";
+  }else{
+    config.urlArgs = config.urlArgs.indexOf("?")==0?config.urlArgs:("?"+config.urlArgs);
+  }
 
   return function(req, res, next) {
     var title = "";
@@ -35,7 +40,7 @@ module.exports = function(config) {
       var output = '';
 
       scripts[place].forEach(function (script) {
-        output += '<script src=' + config.jsPath + '/' + script.src;
+        output += '<script src=' + config.jsPath + '/' + script.src + config.urlArgs;
         for (attribute in script.attributes) {
           output += ' ' + attribute + '="' + script.attributes[attribute] + '"';
         }
@@ -49,7 +54,7 @@ module.exports = function(config) {
       var output = '';
 
       styles.forEach(function (style) {
-        output += '<link href="' + config.cssPath + style.src + '"';
+          output += '<link href="' + config.cssPath + style.src + config.urlArgs + '"';
         for (attribute in style.attributes) {
           output += ' ' + attribute + '="' + style.attributes[attribute] + '"';
         }


### PR DESCRIPTION
- urlArgs configuration was added in order to allow specifying site wide asset query string arguments (useful for versioning/caching, but can be used for any purpose)
- Also added support for absolute urls like: https//cdnjs.cloudflare.com/ajax/libs/require.min.js.
  Relative url support is kept intact( no configuration is needed detection is done on the fly)
- README was updated to support the changes above.
