### PR TITLE
Added missing quotes to js src attrbute

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,19 +100,26 @@ The rendered HTML will look like this:
 * `urlArgs` are extra query string arguments appended to relative path URLs
 
 The above configuration is ignored if absolute url is provided. eg:
+
 ```js
 addScript('footer', 'https://cdnjs.cloudflare.com/ajax/libs/require.min.js')
 ```
+
 OR
-````js
+
+```js
 addScript('footer', '//cdnjs.cloudflare.com/ajax/libs/require.min.js')
 ```
+
 OR
+
 ```js
 addScript('footer', 'http//cdnjs.cloudflare.com/ajax/libs/equire.min.js')
 ```
+
 Then the original url is used and for example in the second case when `scripts('footer')`
 is called, no matter what configuration is used, it will result to:
+
 ```html
 <script src="//cdnjs.cloudflare.com/ajax/libs/require.min.js"></script>
 ```

--- a/lib/ejs-helper.js
+++ b/lib/ejs-helper.js
@@ -75,7 +75,7 @@ module.exports = function(config) {
       var output = '';
 
       scripts[place].forEach(function (script) {
-          output += '<script src=' + constructUrl("jsPath", script.src);
+          output += '<script src="' + constructUrl("jsPath", script.src)+'"';
         for (attribute in script.attributes) {
           output += ' ' + attribute + '="' + script.attributes[attribute] + '"';
         }


### PR DESCRIPTION
I realised that quotes on script scr attribute are missing and by having alook at the [inital commit](https://github.com/timomeh/ejs-helper/blob/4a1aba7ff21af36040413d097aae978805e406a1/lib/ejs-helper.js)  I guess this was a bug that resisted over time since modern browsers mitigate it appropriately  and nobody realized xD. Anw here you are, fixed and tested.
